### PR TITLE
Remove extra steps from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,3 @@
 ### Code review
 
 - [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
-- [ ] "Ready for review" label attached and reviewers assigned
-- [ ] Changes have been reviewed by at least one other contributor
-- [ ] Pull request linked to task tracker where applicable


### PR DESCRIPTION
## Change description

> The "Ready for review" label does not yet exist, and we don't have plans to use it right now. Additionally, another section of the template already requests the task link, and the reviewer requirements are enforced on each repo, so the extra checkboxes were unnecessary.  

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
